### PR TITLE
hint for required minimum PHP Version

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -17,3 +17,8 @@ git clone https://github.com/justonestep/processwire-validator.git your/path/sit
 2. Login to ProcessWire admin and click Modules.
 3. Click "Check for new modules".
 4. Click "install" next to the new Validator module. 
+
+
+## Requirements
+
+- PHP: 5.4 or higher


### PR DESCRIPTION
tried to install the modul locally on PHP 5.3.8 -> error for lib/AbstractValidator 'unexpected "[" on Line 7'
new try with PHP 5.6.8 works.

Think it has something to do with Array dereferencing, what is there until version 5.4
