### PR TITLE
IsEmailValidator: parse error with empty()

### DIFF
--- a/lib/IsEmailValidator.php
+++ b/lib/IsEmailValidator.php
@@ -13,8 +13,9 @@ class IsEmailValidator extends AbstractValidator implements ValidatorInterface {
 
   public function validate($value, $conf = array()) {
     if (!is_array($conf)) throw new WireException('Config must be of type array but is of type ' . gettype($conf) . '.');
+    $sanitizedValue = wire('sanitizer')->email($value);
 
-    if (empty(wire('sanitizer')->email($value))) {
+    if (empty($sanitizedValue)) {
       $this->setValue($value);
       $this->setIsValid(false);
       $this->addError(self::EMAIL_IS_INVALID);


### PR DESCRIPTION
Hi! The `empty()` call here was throwing a PHP error (on PHP 5.4).

> Prior to PHP 5.5, empty() only supports variables; anything else will result in a parse error. In other words, the following will not work: empty(trim($name)). Instead, use trim($name) == false. (http://php.net/manual/en/function.empty.php)

I read in #1 that you're looking to update the module to support the same PHP version as  ProcessWire itself. Hope this helps!
