### PR TITLE
Bugfix, validator names

### DIFF
--- a/Validator.module
+++ b/Validator.module
@@ -43,16 +43,16 @@ class Validator extends WireData implements Module {
    * array available validators
    */
   protected static $validators = array(
-    'containsAtLeast',
-    'isEmail',
-    'isEmpty',
-    'isEqual',
-    'isEqualLength',
-    'isUnique',
-    'maxLength',
-    'minLength',
-    'noWhitespace',
-    'range',
+    'ContainsAtLeast',
+    'IsEmail',
+    'IsEmpty',
+    'IsEqual',
+    'IsEqualLength',
+    'IsUnique',
+    'MaxLength',
+    'MinLength',
+    'NoWhitespace',
+    'Range',
   );
 
   protected $errors = array();


### PR DESCRIPTION
Changed names of available validators in $validators array to titlecase. In some cases (seems to depend on PHP version/settings) include/require is case sensitive, and in this case it couldn't find the validator class files.
